### PR TITLE
Trim and remove 2 or more whitespace characters with just 1 space char

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -32,7 +32,7 @@
                         
                         var $this               = $(this),                              
                             keepSpans           = $("span.slabtext", $this).length,
-                            words               = keepSpans ? [] : String($this.text()).replace(/\s{2,}/g).split(" "),                              
+                            words               = keepSpans ? [] : String($.trim($this.text())).replace(/\s{2,}/g, " ").split(" "),                              
                             origFontSize        = null,                                 
                             idealCharPerLine    = null,                                 
                             fontRatio           = settings.fontRatio,                   


### PR DESCRIPTION
Regex replaced "\n " with 'undefined', then converted to a string, plus removing white space from the front and rear of the string helps with consistency.
