### PR TITLE
Maximum font size

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -17,7 +17,7 @@
             "viewportBreakpoint"    : null,
             // Don't attach a resize event
             "noResizeEvent"         : false,
-            "maxFontSize"           : 80
+            "maxFontSize"           : 9999
             };
         
         // Add the slabtexted classname to the body to initiate the styling of


### PR DESCRIPTION
Hi again,
On our site(www.urbankbh.dk) I've added one more fix to plugin - maximum font size for slubs. As you might seen we have blocks with limited height so when we have very short 1-char slabs page looks ugly.
Please consider adding this fix as well
