### PR TITLE
Typo-fix in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
   <pre><code>.slabtexted .slabtext
         {
         display:-moz-inline-box;
-        display:inline-block
+        display:inline-block;
         white-space:nowrap;
         }
 .slabtextinactive .slabtext
@@ -274,7 +274,7 @@
         }
 .slabtextdone .slabtext
         {
-        display:block
+        display:block;
         }
 </code></pre>        
   <p>The <code>span</code> elements added to the headline are given the class <code>slabtext</code> and the document <code>body</code> given the class <code>slabtexted</code>.</p>  


### PR DESCRIPTION
Without the semicolons, the white-space rule gets ignored. This causes inconsistent undesired wrapping when the plugin is used and dimwits like me blindly copy & paste the CSS.
