### PR TITLE
HTML escaping

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -138,7 +138,17 @@
                                 finalText = postText;
                             };
 
-                            lineText.push('<span class="slabtext">' + $.trim(settings.wrapAmpersand ? finalText.replace(/&/g, '<span class="amp">&amp;</span>') : finalText) + "</span>");
+                            // HTML-escape the text
+                            finalText = $('<div/>').text(finalText).html()
+
+                            // Wrap ampersands in spans with class `amp` for specific styling
+                            if(settings.wrapAmpersand) {
+                                finalText = finalText.replace(/&amp;/g, '<span class="amp">&amp;</span>');
+                            }
+
+                            finalText = $.trim(finalText)
+
+                            lineText.push('<span class="slabtext">' + finalText + "</span>");
                         };
                                     
                         $this.html(lineText.join(" "));


### PR DESCRIPTION
Added escaping of HTML-unsafe characters, eg `<` and `>`, which were not getting preserved when automatically creating word groups. Also, I fixed ampersand wrapping to wrap all ampersands, not just the first.

Source html: "CRAS &amp;lt;VESTIBULUM&amp;gt; &amp;amp; ELIT &amp;amp; INCEPTOS"

Without escaping & wrapping all ampersands:

![](http://skitch.droptype.com/Screen shot 2012-09-25 at 1.29.10 PM.png)

With:

![](http://skitch.droptype.com/Screen shot 2012-09-25 at 1.29.01 PM.png)
