### PR TITLE
Infinite loop of resizeSlabs 'while' if parentWidth is 0

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -78,6 +78,11 @@
                 // Cache the parent containers width       
                 var parentWidth = $this.width(),
                     fs;
+                    
+                //Sanity check to prevent infinite loop
+                if ( parentWidth === 0 ) {
+                    return;
+                }
                 
                 // Remove the slabtextdone and slabtextinactive classnames to enable the inline-block shrink-wrap effect
                 $this.removeClass("slabtextdone slabtextinactive");


### PR DESCRIPTION
Hey,

I found an issue where I was trying to use slabText in a rotator but forgot that if something is set to `display: none` it doesn't have a width/height. This caused slabText to go into an infinite loop in the `while` in the `resizeSlabs` function and kill my browser (tested in FF/Chrome on Windows).

I'm not sure if it's the most elegant solution but I added a sanity check to prevent the infinite looping if the parentWidth is 0. It simply drops out of `resizeSlabs`.

Thanks,
Pat
