### PR TITLE
wrap resizeSlabs() with load binding it will wait until document is read...

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -224,7 +224,9 @@
             };
 
             // Immediate resize
-            resizeSlabs();
+            $(window).bind("load", function() {
+                resizeSlabs();
+            });
 
             if(!settings.noResizeEvent) {
                 $(window).resize(function() {


### PR DESCRIPTION
Fixes cases where slabtext is adjusted before custom font is loaded. This issue usually happens on the first page load when @font-face is first being loaded.

![screen shot 2013-05-29 at 4 20 45 pm](https://f.cloud.github.com/assets/93699/582251/75bfc6aa-c8b6-11e2-9857-826e4642cce6.png)
![screen shot 2013-05-29 at 4 20 59 pm](https://f.cloud.github.com/assets/93699/582252/75bf4f90-c8b6-11e2-91b0-d537c3e28add.png)
