### PR TITLE
Added check newCharPerLine not being zero

### DIFF
--- a/js/jquery.slabtext.js
+++ b/js/jquery.slabtext.js
@@ -115,7 +115,7 @@
                         preDiff,
                         postDiff;
 
-                    if(newCharPerLine != idealCharPerLine) {
+                    if(newCharPerLine != 0 && newCharPerLine != idealCharPerLine) {
                         idealCharPerLine = newCharPerLine;
 
                         while (wordIndex < words.length) {


### PR DESCRIPTION
Added check newCharPerLine not being zero to fix an endless loop condition on text with only two unicode characters (they displayed as boxes in Chrome due the current font not having a map for them)

I ran into this and ended up with an endless loop.  This fixes that.
