### PR TITLE
Load jQuery over HTTPS so demo page works correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="utf-8" />
-    <title>slabText &ndash; a jQuery plugin for creating big, bold &amp; responsive headlines</title>
+    <title>slabText &mdash; a jQuery plugin for creating big, bold &amp; responsive headlines</title>
     <!-- slabtext stylesheet -->
     <link href="./css/slabtext.css" rel="stylesheet" type="text/css" />
     <!-- demo styles inline --> 
@@ -346,7 +346,7 @@
 $("#myHeader").html(stS + txt.join(stE + stS) + stE).slabText();</code></pre>
     </section>
   </footer>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
   <script src="./js/jquery.slabtext.min.js"></script>
   <script>
     // Function to slabtext the H1 headings


### PR DESCRIPTION
Depending on browser settings, many browsers won’t load JavaScript files over HTTP on a page served over HTTPS. The slabText demo page doesn’t load properly in this case. I’ve updated the script’s address to point to the secure version.