### PR TITLE
Move component.json to latest version of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "slabText",
+  "version": "2.4.0",
+  "main": [
+    "js/jquery.slabtext.js",
+    "css/slabtext.css"
+  ],
+  "dependencies": {
+    "jquery": ">=1.4.2"
+  },
+  "homepage": "https://github.com/freqdec/slabText",
+  "authors": [
+    "Brian McAllister"
+  ],
+  "description": "A jQuery plugin for producing big, bold & responsive headlines.",
+  "keywords": [
+    "text",
+    "headlines"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,8 +1,0 @@
-{
-  "name": "slabText",
-  "version": "2.4.0",
-  "main": ["js/jquery.slabtext.js", "css/slabtext.css"],
-  "dependencies": {
-    "jquery": ">=1.4.2"
-  }
-}


### PR DESCRIPTION
component.json has been deprecated for bower.json, this  provides an update to the latest bower.json format.